### PR TITLE
Refactor SyncManager to remove stale queue and ready signal useEffects

### DIFF
--- a/src/client/features/Sync/socketRegistry.ts
+++ b/src/client/features/Sync/socketRegistry.ts
@@ -1,0 +1,16 @@
+import type { Socket } from 'socket.io-client';
+import type { ClientToServerEvents, ServerToClientEvents } from '../../../shared/types';
+
+type SyncSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+// Simple registry to make the socket accessible outside of React components
+// This allows middleware to emit socket events without prop drilling
+let registeredSocket: SyncSocket | null = null;
+
+export function registerSocket(socket: SyncSocket | null): void {
+  registeredSocket = socket;
+}
+
+export function getSocket(): SyncSocket | null {
+  return registeredSocket;
+}

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -3,7 +3,7 @@ import * as RR from 'react-redux';
 
 import debugSlice, { debugMiddleware } from './features/Debug/debugSlice';
 import pageSlice from './features/Page/pageSlice';
-import syncSlice from './features/Sync/syncSlice';
+import syncSlice, { syncMiddleware } from './features/Sync/syncSlice';
 import updateSlice from './features/Update/updateSlice';
 import userReducer from './features/User/userSlice';
 import docsSlice from './state/docsSlice';
@@ -18,7 +18,8 @@ function createStore() {
       debug: debugSlice,
       update: updateSlice,
     },
-    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(debugMiddleware),
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(debugMiddleware, syncMiddleware),
     // devTools: process.env.NODE_ENV !== 'production',
   });
 }


### PR DESCRIPTION
## Summary
- Create socketRegistry to make socket accessible outside React components
- Add syncMiddleware that emits docUpdate when markStale action is dispatched
- Move socket ready signal directly into handleFullSync completion using socketRef
- Remove two reactive useEffects that were causing cascading state updates

This completes the fifth priority from the useEffect elimination plan.

## Test plan
- [ ] Verify sync still works when connecting to server
- [ ] Verify document updates are emitted to other clients
- [ ] Verify ready signal is sent after sync completes
- [ ] Run existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)